### PR TITLE
Add autotool for downloading and testing AtCoder problems

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+autotool

--- a/cmd/autotool/init.go
+++ b/cmd/autotool/init.go
@@ -102,7 +102,30 @@ func parseTestCases(html string) []TestCase {
 	return tcs
 }
 
+func findContestDirByID(contestID string) string {
+	entries, err := os.ReadDir("cmd")
+	if err != nil {
+		return ""
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			name := entry.Name()
+			if strings.HasSuffix(name, "_"+contestID) {
+				return filepath.Join("cmd", name)
+			}
+		}
+	}
+	return ""
+}
+
 func initContest(contestID string) error {
+	existingDir := findContestDirByID(contestID)
+	if existingDir != "" {
+		fmt.Printf("Contest directory %s already exists. Skipping initialization.\n", existingDir)
+		return nil
+	}
+
 	fmt.Printf("Initializing contest %s...\n", contestID)
 
 	tasksURL := fmt.Sprintf("https://atcoder.jp/contests/%s/tasks", contestID)

--- a/cmd/autotool/init.go
+++ b/cmd/autotool/init.go
@@ -12,9 +12,12 @@ import (
 	"time"
 )
 
-func getHTTPClient() *http.Client {
-	return &http.Client{}
-}
+var httpClient = &http.Client{}
+
+var (
+	reIn  = regexp.MustCompile(`(?is)<h3>Sample Input (\d+)</h3>.*?<pre>(.*?)</pre>`)
+	reOut = regexp.MustCompile(`(?is)<h3>Sample Output (\d+)</h3>.*?<pre>(.*?)</pre>`)
+)
 
 func fetchWithAuth(url string) (string, error) {
 	req, err := http.NewRequest("GET", url, nil)
@@ -27,8 +30,7 @@ func fetchWithAuth(url string) (string, error) {
 		req.Header.Set("Cookie", "REVEL_SESSION="+sessionCookie)
 	}
 
-	client := getHTTPClient()
-	resp, err := client.Do(req)
+	resp, err := httpClient.Do(req)
 	if err != nil {
 		return "", err
 	}
@@ -72,9 +74,6 @@ type TestCase struct {
 }
 
 func parseTestCases(html string) []TestCase {
-	reIn := regexp.MustCompile(`(?is)<h3>Sample Input (\d+)</h3>.*?<pre>(.*?)</pre>`)
-	reOut := regexp.MustCompile(`(?is)<h3>Sample Output (\d+)</h3>.*?<pre>(.*?)</pre>`)
-
 	ins := reIn.FindAllStringSubmatch(html, -1)
 	outs := reOut.FindAllStringSubmatch(html, -1)
 
@@ -103,20 +102,18 @@ func parseTestCases(html string) []TestCase {
 	return tcs
 }
 
-func initContest(contestID string) {
+func initContest(contestID string) error {
 	fmt.Printf("Initializing contest %s...\n", contestID)
 
 	tasksURL := fmt.Sprintf("https://atcoder.jp/contests/%s/tasks", contestID)
 	html, err := fetchWithAuth(tasksURL)
 	if err != nil {
-		fmt.Printf("Failed to fetch tasks list: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to fetch tasks list: %w", err)
 	}
 
 	tasks := parseTasks(contestID, html)
 	if len(tasks) == 0 {
-		fmt.Printf("No tasks found for contest %s. Ensure the contest exists and check REVEL_SESSION if it's ongoing.\n", contestID)
-		os.Exit(1)
+		return fmt.Errorf("no tasks found for contest %s. Ensure the contest exists and check REVEL_SESSION if it's ongoing", contestID)
 	}
 
 	dateStr := time.Now().Format("20060102")
@@ -129,7 +126,7 @@ func initContest(contestID string) {
 		label := task.Label
 		taskDir := filepath.Join(baseDir, label)
 
-		if err := os.MkdirAll(taskDir, os.ModePerm); err != nil {
+		if err := os.MkdirAll(taskDir, 0755); err != nil {
 			fmt.Printf("Failed to create dir %s: %v\n", taskDir, err)
 			continue
 		}
@@ -152,14 +149,18 @@ func initContest(contestID string) {
 		tcs := parseTestCases(taskHTML)
 		if len(tcs) > 0 {
 			testDir := filepath.Join(taskDir, "test")
-			os.MkdirAll(testDir, os.ModePerm)
+			os.MkdirAll(testDir, 0755)
 
 			for i, tc := range tcs {
 				inFile := filepath.Join(testDir, fmt.Sprintf("in_%d.txt", i+1))
 				outFile := filepath.Join(testDir, fmt.Sprintf("out_%d.txt", i+1))
 
-				os.WriteFile(inFile, []byte(tc.Input), 0644)
-				os.WriteFile(outFile, []byte(tc.Output), 0644)
+				if err := os.WriteFile(inFile, []byte(tc.Input), 0644); err != nil {
+					fmt.Printf("Error writing file %s: %v\n", inFile, err)
+				}
+				if err := os.WriteFile(outFile, []byte(tc.Output), 0644); err != nil {
+					fmt.Printf("Error writing file %s: %v\n", outFile, err)
+				}
 			}
 			fmt.Printf("Downloaded %d test cases for %s (%s).\n", len(tcs), label, task.ID)
 		} else {
@@ -167,4 +168,5 @@ func initContest(contestID string) {
 		}
 	}
 	fmt.Println("Initialization complete.")
+	return nil
 }

--- a/cmd/autotool/init.go
+++ b/cmd/autotool/init.go
@@ -1,0 +1,170 @@
+package main
+
+import (
+	"atcoder/template"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+func getHTTPClient() *http.Client {
+	return &http.Client{}
+}
+
+func fetchWithAuth(url string) (string, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	sessionCookie := os.Getenv("REVEL_SESSION")
+	if sessionCookie != "" {
+		req.Header.Set("Cookie", "REVEL_SESSION="+sessionCookie)
+	}
+
+	client := getHTTPClient()
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return "", fmt.Errorf("unexpected status code %d for %s", resp.StatusCode, url)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+
+	return string(body), nil
+}
+
+type Task struct {
+	Label string
+	ID    string
+}
+
+func parseTasks(contestID string, html string) []Task {
+	pattern := fmt.Sprintf(`<td class="text-center no-break"><a href="/contests/%s/tasks/([^"]+)">([^<]+)</a></td>`, contestID)
+	re := regexp.MustCompile(pattern)
+	matches := re.FindAllStringSubmatch(html, -1)
+
+	var tasks []Task
+	for _, m := range matches {
+		tasks = append(tasks, Task{
+			ID:    m[1],
+			Label: m[2],
+		})
+	}
+	return tasks
+}
+
+type TestCase struct {
+	Input  string
+	Output string
+}
+
+func parseTestCases(html string) []TestCase {
+	reIn := regexp.MustCompile(`(?is)<h3>Sample Input (\d+)</h3>.*?<pre>(.*?)</pre>`)
+	reOut := regexp.MustCompile(`(?is)<h3>Sample Output (\d+)</h3>.*?<pre>(.*?)</pre>`)
+
+	ins := reIn.FindAllStringSubmatch(html, -1)
+	outs := reOut.FindAllStringSubmatch(html, -1)
+
+	var tcs []TestCase
+
+	outMap := make(map[string]string)
+	for _, out := range outs {
+		outMap[out[1]] = strings.TrimLeft(out[2], "\r\n")
+	}
+
+	seenInput := make(map[string]bool)
+	for _, in := range ins {
+		id := in[1]
+		inStr := strings.TrimLeft(in[2], "\r\n")
+		outStr := outMap[id]
+
+		if !seenInput[inStr] {
+			seenInput[inStr] = true
+			tcs = append(tcs, TestCase{
+				Input:  inStr,
+				Output: outStr,
+			})
+		}
+	}
+
+	return tcs
+}
+
+func initContest(contestID string) {
+	fmt.Printf("Initializing contest %s...\n", contestID)
+
+	tasksURL := fmt.Sprintf("https://atcoder.jp/contests/%s/tasks", contestID)
+	html, err := fetchWithAuth(tasksURL)
+	if err != nil {
+		fmt.Printf("Failed to fetch tasks list: %v\n", err)
+		os.Exit(1)
+	}
+
+	tasks := parseTasks(contestID, html)
+	if len(tasks) == 0 {
+		fmt.Printf("No tasks found for contest %s. Ensure the contest exists and check REVEL_SESSION if it's ongoing.\n", contestID)
+		os.Exit(1)
+	}
+
+	dateStr := time.Now().Format("20060102")
+	dirName := fmt.Sprintf("%s_%s", dateStr, contestID)
+	baseDir := filepath.Join("cmd", dirName)
+
+	fmt.Printf("Creating directory %s...\n", baseDir)
+
+	for _, task := range tasks {
+		label := task.Label
+		taskDir := filepath.Join(baseDir, label)
+
+		if err := os.MkdirAll(taskDir, os.ModePerm); err != nil {
+			fmt.Printf("Failed to create dir %s: %v\n", taskDir, err)
+			continue
+		}
+
+		goFile := filepath.Join(taskDir, label+".go")
+		if _, err := os.Stat(goFile); os.IsNotExist(err) {
+			err = os.WriteFile(goFile, template.Template, 0644)
+			if err != nil {
+				fmt.Printf("Failed to write template to %s: %v\n", goFile, err)
+			}
+		}
+
+		taskURL := fmt.Sprintf("https://atcoder.jp/contests/%s/tasks/%s", contestID, task.ID)
+		taskHTML, err := fetchWithAuth(taskURL)
+		if err != nil {
+			fmt.Printf("Failed to fetch task %s: %v\n", task.ID, err)
+			continue
+		}
+
+		tcs := parseTestCases(taskHTML)
+		if len(tcs) > 0 {
+			testDir := filepath.Join(taskDir, "test")
+			os.MkdirAll(testDir, os.ModePerm)
+
+			for i, tc := range tcs {
+				inFile := filepath.Join(testDir, fmt.Sprintf("in_%d.txt", i+1))
+				outFile := filepath.Join(testDir, fmt.Sprintf("out_%d.txt", i+1))
+
+				os.WriteFile(inFile, []byte(tc.Input), 0644)
+				os.WriteFile(outFile, []byte(tc.Output), 0644)
+			}
+			fmt.Printf("Downloaded %d test cases for %s (%s).\n", len(tcs), label, task.ID)
+		} else {
+			fmt.Printf("No test cases found for %s (%s).\n", label, task.ID)
+		}
+	}
+	fmt.Println("Initialization complete.")
+}

--- a/cmd/autotool/main.go
+++ b/cmd/autotool/main.go
@@ -30,7 +30,7 @@ func main() {
 	if len(os.Args) < 2 {
 		fmt.Println("Usage:")
 		fmt.Println("  autotool init [flags] <contest_id>")
-		fmt.Println("  autotool test <problem_label>")
+		fmt.Println("  autotool test [flags] <problem_label>")
 		os.Exit(1)
 	}
 
@@ -38,6 +38,7 @@ func main() {
 	cookieFlag := initCmd.String("cookie", "", "Session cookie (e.g., REVEL_SESSION=...)")
 
 	testCmd := flag.NewFlagSet("test", flag.ExitOnError)
+	contestFlag := testCmd.String("contest", "", "Specify a specific contest ID to test (e.g., abc300)")
 
 	command := os.Args[1]
 
@@ -66,11 +67,12 @@ func main() {
 	case "test":
 		testCmd.Parse(os.Args[2:])
 		if testCmd.NArg() < 1 {
-			fmt.Println("Usage: autotool test <problem_label>")
+			fmt.Println("Usage: autotool test [flags] <problem_label>")
+			testCmd.PrintDefaults()
 			os.Exit(1)
 		}
 		problemLabel := testCmd.Arg(0)
-		if err := testProblem(problemLabel); err != nil {
+		if err := testProblem(problemLabel, *contestFlag); err != nil {
 			fmt.Printf("Test failed: %v\n", err)
 			os.Exit(1)
 		}

--- a/cmd/autotool/main.go
+++ b/cmd/autotool/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
 	"strings"
@@ -26,45 +27,53 @@ func loadEnv() {
 func main() {
 	loadEnv()
 
-	// Parse flags and remove them from os.Args
-	var filteredArgs []string
-	for _, arg := range os.Args {
-		if strings.HasPrefix(arg, "--cookie=") {
-			cookieStr := strings.TrimPrefix(arg, "--cookie=")
-			if strings.HasPrefix(cookieStr, "REVEL_SESSION=") {
-				cookieStr = strings.TrimPrefix(cookieStr, "REVEL_SESSION=")
-			}
-			os.Setenv("REVEL_SESSION", cookieStr)
-		} else {
-			filteredArgs = append(filteredArgs, arg)
-		}
-	}
-	os.Args = filteredArgs
-
 	if len(os.Args) < 2 {
 		fmt.Println("Usage:")
-		fmt.Println("  autotool init <contest_id> [--cookie=\"REVEL_SESSION=...\"]")
+		fmt.Println("  autotool init [flags] <contest_id>")
 		fmt.Println("  autotool test <problem_label>")
 		os.Exit(1)
 	}
+
+	initCmd := flag.NewFlagSet("init", flag.ExitOnError)
+	cookieFlag := initCmd.String("cookie", "", "Session cookie (e.g., REVEL_SESSION=...)")
+
+	testCmd := flag.NewFlagSet("test", flag.ExitOnError)
 
 	command := os.Args[1]
 
 	switch command {
 	case "init":
-		if len(os.Args) < 3 {
-			fmt.Println("Usage: autotool init <contest_id> [--cookie=\"REVEL_SESSION=...\"]")
+		initCmd.Parse(os.Args[2:])
+		if initCmd.NArg() < 1 {
+			fmt.Println("Usage: autotool init [flags] <contest_id>")
+			initCmd.PrintDefaults()
 			os.Exit(1)
 		}
-		contestID := os.Args[2]
-		initContest(contestID)
+
+		if *cookieFlag != "" {
+			cookieStr := *cookieFlag
+			if strings.HasPrefix(cookieStr, "REVEL_SESSION=") {
+				cookieStr = strings.TrimPrefix(cookieStr, "REVEL_SESSION=")
+			}
+			os.Setenv("REVEL_SESSION", cookieStr)
+		}
+
+		contestID := initCmd.Arg(0)
+		if err := initContest(contestID); err != nil {
+			fmt.Printf("Init failed: %v\n", err)
+			os.Exit(1)
+		}
 	case "test":
-		if len(os.Args) < 3 {
+		testCmd.Parse(os.Args[2:])
+		if testCmd.NArg() < 1 {
 			fmt.Println("Usage: autotool test <problem_label>")
 			os.Exit(1)
 		}
-		problemLabel := os.Args[2]
-		testProblem(problemLabel)
+		problemLabel := testCmd.Arg(0)
+		if err := testProblem(problemLabel); err != nil {
+			fmt.Printf("Test failed: %v\n", err)
+			os.Exit(1)
+		}
 	default:
 		fmt.Printf("Unknown command: %s\n", command)
 		os.Exit(1)

--- a/cmd/autotool/main.go
+++ b/cmd/autotool/main.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+func loadEnv() {
+	content, err := os.ReadFile(".env")
+	if err == nil {
+		lines := strings.Split(string(content), "\n")
+		for _, line := range lines {
+			line = strings.TrimSpace(line)
+			if line == "" || strings.HasPrefix(line, "#") {
+				continue
+			}
+			parts := strings.SplitN(line, "=", 2)
+			if len(parts) == 2 {
+				os.Setenv(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+			}
+		}
+	}
+}
+
+func main() {
+	loadEnv()
+
+	// Parse flags and remove them from os.Args
+	var filteredArgs []string
+	for _, arg := range os.Args {
+		if strings.HasPrefix(arg, "--cookie=") {
+			cookieStr := strings.TrimPrefix(arg, "--cookie=")
+			if strings.HasPrefix(cookieStr, "REVEL_SESSION=") {
+				cookieStr = strings.TrimPrefix(cookieStr, "REVEL_SESSION=")
+			}
+			os.Setenv("REVEL_SESSION", cookieStr)
+		} else {
+			filteredArgs = append(filteredArgs, arg)
+		}
+	}
+	os.Args = filteredArgs
+
+	if len(os.Args) < 2 {
+		fmt.Println("Usage:")
+		fmt.Println("  autotool init <contest_id> [--cookie=\"REVEL_SESSION=...\"]")
+		fmt.Println("  autotool test <problem_label>")
+		os.Exit(1)
+	}
+
+	command := os.Args[1]
+
+	switch command {
+	case "init":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: autotool init <contest_id> [--cookie=\"REVEL_SESSION=...\"]")
+			os.Exit(1)
+		}
+		contestID := os.Args[2]
+		initContest(contestID)
+	case "test":
+		if len(os.Args) < 3 {
+			fmt.Println("Usage: autotool test <problem_label>")
+			os.Exit(1)
+		}
+		problemLabel := os.Args[2]
+		testProblem(problemLabel)
+	default:
+		fmt.Printf("Unknown command: %s\n", command)
+		os.Exit(1)
+	}
+}

--- a/cmd/autotool/test.go
+++ b/cmd/autotool/test.go
@@ -34,13 +34,12 @@ func findLatestContestDir() string {
 	return filepath.Join("cmd", dirs[len(dirs)-1])
 }
 
-func testProblem(problemLabel string) {
+func testProblem(problemLabel string) error {
 	fmt.Printf("Testing problem %s...\n", problemLabel)
 
 	latestDir := findLatestContestDir()
 	if latestDir == "" {
-		fmt.Println("No contest directory found (expected cmd/YYYYMMDD_<contest_id>).")
-		os.Exit(1)
+		return fmt.Errorf("no contest directory found (expected cmd/YYYYMMDD_<contest_id>)")
 	}
 
 	fmt.Printf("Using contest directory: %s\n", latestDir)
@@ -50,12 +49,10 @@ func testProblem(problemLabel string) {
 	testDir := filepath.Join(taskDir, "test")
 
 	if _, err := os.Stat(goFile); os.IsNotExist(err) {
-		fmt.Printf("Go file not found: %s\n", goFile)
-		os.Exit(1)
+		return fmt.Errorf("Go file not found: %s", goFile)
 	}
 	if _, err := os.Stat(testDir); os.IsNotExist(err) {
-		fmt.Printf("Test directory not found: %s\n", testDir)
-		os.Exit(1)
+		return fmt.Errorf("Test directory not found: %s", testDir)
 	}
 
 	binFile := filepath.Join(taskDir, "exec_bin")
@@ -68,15 +65,13 @@ func testProblem(problemLabel string) {
 	buildCmd.Stderr = os.Stderr
 	buildCmd.Stdout = os.Stdout
 	if err := buildCmd.Run(); err != nil {
-		fmt.Printf("Compilation failed: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("compilation failed: %w", err)
 	}
 	defer os.Remove(binFile)
 
 	entries, err := os.ReadDir(testDir)
 	if err != nil {
-		fmt.Printf("Failed to read test directory: %v\n", err)
-		os.Exit(1)
+		return fmt.Errorf("failed to read test directory: %w", err)
 	}
 
 	passed := 0
@@ -139,6 +134,7 @@ func testProblem(problemLabel string) {
 
 	fmt.Printf("\nSummary: %d / %d tests passed.\n", passed, total)
 	if passed != total {
-		os.Exit(1)
+		return fmt.Errorf("not all tests passed")
 	}
+	return nil
 }

--- a/cmd/autotool/test.go
+++ b/cmd/autotool/test.go
@@ -34,17 +34,25 @@ func findLatestContestDir() string {
 	return filepath.Join("cmd", dirs[len(dirs)-1])
 }
 
-func testProblem(problemLabel string) error {
+func testProblem(problemLabel string, specificContestID string) error {
 	fmt.Printf("Testing problem %s...\n", problemLabel)
 
-	latestDir := findLatestContestDir()
-	if latestDir == "" {
-		return fmt.Errorf("no contest directory found (expected cmd/YYYYMMDD_<contest_id>)")
+	var targetDir string
+	if specificContestID != "" {
+		targetDir = findContestDirByID(specificContestID)
+		if targetDir == "" {
+			return fmt.Errorf("no contest directory found for %s", specificContestID)
+		}
+	} else {
+		targetDir = findLatestContestDir()
+		if targetDir == "" {
+			return fmt.Errorf("no contest directory found (expected cmd/YYYYMMDD_<contest_id>)")
+		}
 	}
 
-	fmt.Printf("Using contest directory: %s\n", latestDir)
+	fmt.Printf("Using contest directory: %s\n", targetDir)
 
-	taskDir := filepath.Join(latestDir, problemLabel)
+	taskDir := filepath.Join(targetDir, problemLabel)
 	goFile := filepath.Join(taskDir, problemLabel+".go")
 	testDir := filepath.Join(taskDir, "test")
 

--- a/cmd/autotool/test.go
+++ b/cmd/autotool/test.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+func findLatestContestDir() string {
+	entries, err := os.ReadDir("cmd")
+	if err != nil {
+		return ""
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if entry.IsDir() {
+			name := entry.Name()
+			if strings.HasPrefix(name, "20") && strings.Contains(name, "_") {
+				dirs = append(dirs, name)
+			}
+		}
+	}
+
+	if len(dirs) == 0 {
+		return ""
+	}
+
+	sort.Strings(dirs)
+	return filepath.Join("cmd", dirs[len(dirs)-1])
+}
+
+func testProblem(problemLabel string) {
+	fmt.Printf("Testing problem %s...\n", problemLabel)
+
+	latestDir := findLatestContestDir()
+	if latestDir == "" {
+		fmt.Println("No contest directory found (expected cmd/YYYYMMDD_<contest_id>).")
+		os.Exit(1)
+	}
+
+	fmt.Printf("Using contest directory: %s\n", latestDir)
+
+	taskDir := filepath.Join(latestDir, problemLabel)
+	goFile := filepath.Join(taskDir, problemLabel+".go")
+	testDir := filepath.Join(taskDir, "test")
+
+	if _, err := os.Stat(goFile); os.IsNotExist(err) {
+		fmt.Printf("Go file not found: %s\n", goFile)
+		os.Exit(1)
+	}
+	if _, err := os.Stat(testDir); os.IsNotExist(err) {
+		fmt.Printf("Test directory not found: %s\n", testDir)
+		os.Exit(1)
+	}
+
+	binFile := filepath.Join(taskDir, "exec_bin")
+	if os.PathSeparator == '\\' {
+		binFile += ".exe"
+	}
+
+	fmt.Printf("Compiling %s...\n", goFile)
+	buildCmd := exec.Command("go", "build", "-o", binFile, goFile)
+	buildCmd.Stderr = os.Stderr
+	buildCmd.Stdout = os.Stdout
+	if err := buildCmd.Run(); err != nil {
+		fmt.Printf("Compilation failed: %v\n", err)
+		os.Exit(1)
+	}
+	defer os.Remove(binFile)
+
+	entries, err := os.ReadDir(testDir)
+	if err != nil {
+		fmt.Printf("Failed to read test directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	passed := 0
+	total := 0
+
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasPrefix(entry.Name(), "in_") {
+			inFileName := entry.Name()
+			id := strings.TrimPrefix(inFileName, "in_")
+			outFileName := "out_" + id
+
+			inFile := filepath.Join(testDir, inFileName)
+			outFile := filepath.Join(testDir, outFileName)
+
+			if _, err := os.Stat(outFile); os.IsNotExist(err) {
+				continue
+			}
+
+			total++
+
+			inContent, err := os.ReadFile(inFile)
+			if err != nil {
+				fmt.Printf("Test %s: Error reading input: %v\n", id, err)
+				continue
+			}
+
+			expectedContent, err := os.ReadFile(outFile)
+			if err != nil {
+				fmt.Printf("Test %s: Error reading output: %v\n", id, err)
+				continue
+			}
+
+			runCmd := exec.Command(binFile)
+			runCmd.Stdin = bytes.NewReader(inContent)
+			var stdout, stderr bytes.Buffer
+			runCmd.Stdout = &stdout
+			runCmd.Stderr = &stderr
+
+			err = runCmd.Run()
+
+			if err != nil {
+				fmt.Printf("Test %s: Runtime error: %v\n", id, err)
+				fmt.Printf("Stderr:\n%s\n", stderr.String())
+				continue
+			}
+
+			actual := strings.TrimSpace(stdout.String())
+			expected := strings.TrimSpace(string(expectedContent))
+
+			if actual == expected {
+				fmt.Printf("Test %s: PASSED\n", id)
+				passed++
+			} else {
+				fmt.Printf("Test %s: FAILED\n", id)
+				fmt.Printf("Expected:\n%s\n", expected)
+				fmt.Printf("Actual:\n%s\n", actual)
+			}
+		}
+	}
+
+	fmt.Printf("\nSummary: %d / %d tests passed.\n", passed, total)
+	if passed != total {
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
This PR introduces a new CLI utility `autotool` under `cmd/autotool/` that automates downloading and testing AtCoder contest problems, fulfilling the user's requirements:
1. `init <contest_id>` scrapes problem labels and parses sample test cases, writing them to a `cmd/YYYYMMDD_<contest_id>` directory along with a base template `.go` file.
2. `test <problem_label>` discovers the latest contest directory, compiles the code for the given problem label, and executes the downloaded tests, comparing outputs and providing a pass/fail summary.
3. Allows `.env` configuration and `--cookie` flags to authenticate for private or ongoing contests.

---
*PR created automatically by Jules for task [10990434117796547338](https://jules.google.com/task/10990434117796547338) started by @Asutorufa*